### PR TITLE
opplot savedata option fixes

### DIFF
--- a/opplot.ado
+++ b/opplot.ado
@@ -1,4 +1,4 @@
-*! opplot version 1.09 - Biostat Global Consulting - 2018-06-22
+*! opplot version 1.10 - Biostat Global Consulting - 2018-08-14
 *******************************************************************************
 * Change log
 * 				Updated
@@ -36,6 +36,9 @@
 *                                        option, if necessary, to yield bars
 *                                        of equal width)
 *
+* 2018-08-14	1.10	Mary Prier		Added line of code that strips out
+*                      					double quotes of savedata option, 
+*										if user supplied filename in double quotes
 *******************************************************************************
 
 program define opplot

--- a/opplot.ado
+++ b/opplot.ado
@@ -203,6 +203,9 @@ program define opplot
 		* particular bar in the figure; the order in which clusterids
 		* appear in the saved dataset is the same order they appear in 
 		* the plot
+		
+		* Strip off double quotes if user supplied filename in double quotes
+		local savedata = subinstr(`"`savedata'"', `"""',  "", .)
 
 		if "`savedata'" != "" {
 			drop in `=_N'

--- a/opplot.sthlp
+++ b/opplot.sthlp
@@ -130,15 +130,17 @@
 	   to IGNORE the weightvar.){p_end}
 	   
 {pstd} {bf:SAVEDATA}(string) - If this option is specified, the command will 
-       save a dataset using the STRATUM name. The dataset includes one row
-	   per bar in the plot.  The left-most bar is represented by row 1 and the
-	   right-most bar by the last row in the dataset.  The dataset holds several
-	   informative columns describing what variable is summarized, how many 
-	   respondents are represented in each bar, the proportion of the population
-	   represented by each bar, and the sample coverage in each bar (rounded to
-	   the nearest percent).  This dataset can be useful for identifying the
-	   cluster ID for bars that show surprisingly low or surprisingly high 
-	   coverage.{p_end}
+       save a dataset using the string specified, which doesn't need to be in
+	   double quotes. The dataset includes one row per bar in the plot.  The 
+	   left-most bar is represented by row 1 and the right-most bar by the last 
+	   row in the dataset.  The dataset holds several informative columns 
+	   describing what variable is summarized, how many respondents are 
+	   represented in each bar, the proportion of the population represented by
+	   each bar, and the sample coverage in each bar (rounded to the nearest 
+	   percent).  This dataset can be useful for identifying the cluster ID for 
+	   bars that show surprisingly low or surprisingly high coverage.  SAVEDATA 
+	   uses the replace option when saving the dataset, so an existing dataset 
+	   with the same filename will be overwritten.{p_end}
 	   
 {pstd} {bf:EXPORTSTRAtumname} - If this option is specified, the command will 
        export a .PNG image of the plot to the current working directory and uses

--- a/opplot_demo.do
+++ b/opplot_demo.do
@@ -83,10 +83,16 @@ opplot y , clustvar(clusterid) stratvar(stratumid) ///
 opplot y , clustvar(clusterid) stratvar(stratumid) ///
 		stratum(0) title(Stratum 0) name(Demo6,replace) ///
 		xsize(20) ysize(6) export(Stratum_0_wide.png)
+		
+ * Demo saving the accompanying dataset and having a look at it            
+opplot y , clustvar(clusterid) stratvar(stratumid) ///
+        stratum(0) title(Stratum 0) name(Demo6,replace) ///
+        xsize(20) ysize(6) savedata(Stratum_6)
+use Stratum_6, clear 
+browse 
 
 * Here is the 'syntax' statement from opplot.  I have demoed the useful
-* features in this program.  The 'savedata' option is currently commented
-* out, but you can uncomment and use it.
+* features in this program.  
 	
 /*		
 	syntax varlist(max=1) [if] [in], CLUSTVAR(varname fv) ///
@@ -98,7 +104,7 @@ opplot y , clustvar(clusterid) stratvar(stratumid) ///
 	 EXPORTSTRAtumname EXPORT(string) EXPORTWidth(integer 2000) ///
 	 SAVING(string asis) NAME(string) SAVEDATA(string asis) ///
 	 XSIZE(real -9) YSIZE(real -9) ]
-	 
 */
 
-* Let me know if you have questions!		
+* Let me know if you have questions!  
+* Email: Dale.Rhoda@biostatglobal.com		


### PR DESCRIPTION
Three files were updated:
1. opplot.ado: line of code added to parse out double quotes of savedata option & updated comments and date at top of file
2. help file updated...noted that savedata requires a filename and that the option overwrites existing databases with the same name
3. demo.do: added savedata option example (which was the same example in the help file) (Note the help and demo files use the same examples now.)